### PR TITLE
Added an IndexPreTransform class and fixed the EncodeVector by adding…

### DIFF
--- a/FaissMask.Test/EncodeDecodeAndAssignTests.cs
+++ b/FaissMask.Test/EncodeDecodeAndAssignTests.cs
@@ -36,11 +36,24 @@ namespace FaissMask.Test
                 labels = index.Assign(vector, 2);
                 Assert.Equal(new long[] { 10, 62 }, labels);
 
+                Console.WriteLine($"vector length={vector.Length}");
+
                 Assert.Equal(8, (int)index.SaCodeSize);
-                var bytes = index.EncodeVector(vector);
-                Assert.Equal(new byte[] { 204, 4, 82, 34, 147, 225, 227, 37 }, bytes);
+                var bytes = index.EncodeVector(vector, 64);
+                Assert.Equal(
+                    new byte[]
+                    {
+                        204, 4, 82, 34, 147, 225, 227, 37, 169, 10, 154, 104, 253, 166, 246, 126, 216, 200, 153, 140,
+                        110, 87, 161, 106, 84, 233, 106, 110, 7, 171, 90, 204, 106, 175, 18, 125, 189, 150, 83, 27, 17,
+                        116, 107, 65, 137, 218, 200, 228, 19, 193, 124, 99, 26, 67, 10, 52, 141, 187, 167, 33, 145, 154,
+                        41, 228
+                    }, bytes);
+                Console.WriteLine($"codes length={bytes.Length}");
+                Console.WriteLine(string.Join(",", bytes));
 
                 var vector2 = index.DecodeVector(bytes);
+                Console.WriteLine("decoded");
+                Console.WriteLine($"decoded length={vector2.Length}");
                 Assert.InRange(vector.CosineSimilarityWith(vector2), 0.9, 1.0);
             }
         }

--- a/FaissMask/Index.cs
+++ b/FaissMask/Index.cs
@@ -102,9 +102,9 @@ namespace FaissMask
 
         public ulong SaCodeSize => Handle.SaCodeSize;
 
-        public byte[] EncodeVector(float[] vector)
+        public byte[] EncodeVector(float[] vector, int numberOfCodes)
         {
-            return Handle.EncodeVector(vector);
+            return Handle.EncodeVector(vector, numberOfCodes);
         }
 
         public float[] DecodeVector(byte[] bytes)

--- a/FaissMask/IndexPreTransform.cs
+++ b/FaissMask/IndexPreTransform.cs
@@ -1,0 +1,20 @@
+using System;
+using FaissMask.Internal;
+
+namespace FaissMask
+{
+    public class IndexPreTransform : Index
+    {
+        internal IndexPreTransform(IndexPreTransformSafeHandle handle) : base(handle)
+        {
+        }
+
+        public static IndexPreTransform Read(string filename)
+        {
+            var handle = IndexSafeHandle.Read(filename, ptr => new IndexPreTransformSafeHandle(ptr));
+            return new IndexPreTransform(handle);
+        }
+
+        IndexPreTransformSafeHandle IndexPreTransformSafeHandle => Handle as IndexPreTransformSafeHandle;
+    }
+}

--- a/FaissMask/Internal/IndexPreTransformSafeHandle.cs
+++ b/FaissMask/Internal/IndexPreTransformSafeHandle.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace FaissMask.Internal
+{
+    internal class IndexPreTransformSafeHandle : IndexSafeHandle
+    {
+        public IndexPreTransformSafeHandle() {}
+        public IndexPreTransformSafeHandle(IntPtr pointer) : base(pointer) {}
+
+        public static IndexPreTransformSafeHandle New()
+        {
+            var index = new IndexPreTransformSafeHandle();
+            NativeMethods.faiss_IndexPreTransform_new(ref index);
+            return index;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            if (!IsFree)
+                Free();
+            return true;
+        }
+    }
+}

--- a/FaissMask/Internal/IndexSafeHandle.cs
+++ b/FaissMask/Internal/IndexSafeHandle.cs
@@ -117,9 +117,9 @@ namespace FaissMask.Internal
             return choppedVectors;
         }
 
-        public byte[] EncodeVector(float[] vector)
+        public byte[] EncodeVector(float[] vector, int numberOfCOdes)
         {
-            var bytes = new byte[SaCodeSize];
+            var bytes = new byte[numberOfCOdes];
             NativeMethods.faiss_Index_sa_encode(this, 1, vector, bytes);
             return bytes;
         }

--- a/FaissMask/Internal/NativeMethods.cs
+++ b/FaissMask/Internal/NativeMethods.cs
@@ -53,5 +53,7 @@ namespace FaissMask.Internal
         public static extern long faiss_IndexIVF_nprobe(IndexSafeHandle index);
         [DllImport("faiss_c", SetLastError = true)]
         public static extern void faiss_IndexIVF_set_nprobe(IndexSafeHandle index, long nProbe);
+        [DllImport("faiss_c", SetLastError = true)]
+        public static extern void faiss_IndexPreTransform_new(ref IndexPreTransformSafeHandle index);
     }
 }


### PR DESCRIPTION
… a parameter for the number of codes to return. If the number of codes requested does not match the number codes in the faiss index, it will lead to memory issues and seg faults. There may be a way to extract them from the c code and to the C API at a later date.